### PR TITLE
Create add_data_dir if it doesn't exist to fix pip install

### DIFF
--- a/serenityff/charge/tree/retrieve_data.py
+++ b/serenityff/charge/tree/retrieve_data.py
@@ -117,6 +117,8 @@ def get_additional_data(
     Raises:
         DataNotComplete: Throw when not all data files necessary where found.
     """
+    if not add_data_folder.exists():
+        add_data_folder.mkdir()
     if isinstance(url, DataUrl):
         url = URL_DICT[url]
     if isinstance(extracted_folder, DataPath):


### PR DESCRIPTION
This changes the code to create the folder `add_data_dir` (which is `serenityff/charge/data/additional_data`) if it doesn't exist. Otherwise, the download will fail after installing with `pip install .`

After cloning the repository and installing with `pip install .` rather than conda develop, I get the error below (replaced my conda directory for CONDA_PREFIX). The reason seems to be that the "additional_data" folder is not created by pip install. By checking if the folder exists, and running mkdir otherwise, the problem seems to be fixed.
```
>>> from serenityff.charge.tree.dash_tree import DASHTree
>>> DASHTree()
Loading DASH tree data
The DASH Tree is missing additional data and will install that. This Can take a few minutes...
Downloading data from ETH research archive...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CONDA_PREFIX/lib/python3.11/site-packages/serenityff/charge/tree/dash_tree.py", line 126, in __init__
    self.load_all_trees_and_data(tree_type=tree_type)
  File "CONDA_PREFIX/lib/python3.11/site-packages/serenityff/charge/tree/dash_tree.py", line 167, in load_all_trees_and_data
    success = get_additional_data()
              ^^^^^^^^^^^^^^^^^^^^^
  File "CONDA_PREFIX/lib/python3.11/site-packages/serenityff/charge/tree/retrieve_data.py", line 127, in get_additional_data
    download_tree_data_from_archive(url=url, file=zip_archive)
  File "CONDA_PREFIX/lib/python3.11/site-packages/serenityff/charge/tree/retrieve_data.py", line 50, in download_tree_data_from_archive
    urlretrieve(url=url, filename=file)
  File "CONDA_PREFIX/lib/python3.11/urllib/request.py", line 251, in urlretrieve
    tfp = open(filename, 'wb')
          ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'CONDA_PREFIX/lib/python3.11/site-packages/serenityff/charge/data/additional_data/additional_data_download.zip'
```