### PR TITLE
Cleanup/environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,21 @@ Content
 Installation
 -------------
 
-   This repository comes with a conda environment file. To install the environment, run the following command in the root directory of this repository:
+   This repository comes with multiple conda environment files:
+
+   - [`tree_only_env.yml`](tree_only_env.yml) : Only the Tree, no OpenFF
+   - [`min_environment.yml`](min_environment.yml) : Tree + OpenFF
+   - [`environment.yml`](environment.yml) : Tree + OpenFF + GNN Utilities
+
+   To install the environment, run the following command in the root directory of this repository:
 
    ```bash
-    conda env create -f min_environment.yml
+    conda env create -f tree_only_env.yml
     conda activate dash
     conda develop .
    ```
 
-This will create a conda environment with the correct packages. The environment contains the minimal dependencies required to use the tree. If the OpenFF plugin to automatically assign charge is required, use the file  `environment.yml` instead. This will create the environment, the DASH package and install the OpenFF plugin for partial charge assignment in OpenFF. The file `environment.yml` also contains all torch dependencies, used for DASH tree development.
+This will create a conda environment with the correct packages. The environment contains the minimal dependencies required to use the tree. If the OpenFF plugin to automatically assign charge is required, use the file  `min_environment.yml` instead. This will create the environment, the DASH package and install the OpenFF plugin for partial charge assignment in OpenFF. The file `environment.yml` also contains all PyTorch dependencies, used for DASH tree development.
 
 
 Usage

--- a/environment.yml
+++ b/environment.yml
@@ -10,9 +10,7 @@ dependencies:
   - numpy
   - m2r
   - conda-build
-  - typing
   - pyarrow
-  - mpmath
   - scipy
   #- nbsphinx
   - pytest

--- a/min_environment.yml
+++ b/min_environment.yml
@@ -9,8 +9,6 @@ dependencies:
   - numpy
   - m2r
   - conda-build
-  - typing
-  - mpmath
   - scipy
   - pytest
   - numba

--- a/tree_only_env.yml
+++ b/tree_only_env.yml
@@ -6,8 +6,6 @@ dependencies:
   - python
   - numpy
   - conda-build
-  - typing
-  - mpmath
   - pandas
   - rdkit
   - pytables


### PR DESCRIPTION
Removing `mpmath` and `typing` from the environment files, since they are not used.

Updated the readme with the correct file names.