### PR TITLE
torch / pyg as pip dependency

### DIFF
--- a/dev/conda-env/test_env.yaml
+++ b/dev/conda-env/test_env.yaml
@@ -2,9 +2,7 @@
 name: serenityff-charge-test
 channels:
   - pytorch
-  - pyg
   - conda-forge
-  - defaults
 dependencies:
   # Base depends
   - python = 3.10
@@ -28,4 +26,5 @@ dependencies:
   - rdkit
   # Machine Learning
   - pytorch = 2.0.0
-  - pyg = 2.3.0
+  - pip:
+    - torch_geometric == 2.3.0

--- a/dev/conda-env/test_env.yaml
+++ b/dev/conda-env/test_env.yaml
@@ -1,7 +1,6 @@
 # TODO: CUDA not installed by default
 name: serenityff-charge-test
 channels:
-  - pytorch
   - conda-forge
 dependencies:
   # Base depends
@@ -25,6 +24,6 @@ dependencies:
   - openff-toolkit = 0.10.0
   - rdkit
   # Machine Learning
-  - pytorch = 2.0.0
   - pip:
+    - pytorch == 2.0.0
     - torch_geometric == 2.3.0

--- a/dev/conda-env/test_env.yaml
+++ b/dev/conda-env/test_env.yaml
@@ -25,5 +25,5 @@ dependencies:
   - rdkit
   # Machine Learning
   - pip:
-    - pytorch == 2.0.0
+    - torch == 2.0.0
     - torch_geometric == 2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,7 @@
 name: dash
 channels:
-  - defaults
   - conda-forge
   - pytorch
-  - pyg
 dependencies:
   - python = 3.10
   - pip
@@ -17,4 +15,5 @@ dependencies:
   - openff-toolkit = 0.10.0
   - rdkit
   - pytorch = 2.0.0
-  - pyg = 2.3.0
+  - pip:
+    - torch_geometric == 2.3.0


### PR DESCRIPTION
following the installation instructions here: https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html and here: https://pytorch.org/get-started/locally/

Apparently it doesn't look like they are supporting conda any further.