### PR TITLE
update link to dash props data

### DIFF
--- a/serenityff/charge/tree/retrieve_data.py
+++ b/serenityff/charge/tree/retrieve_data.py
@@ -27,7 +27,7 @@ class DataPath(Enum):
 
 URL_DICT = {
     DataUrl.DEFAULT: None,
-    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/bitstream/handle/20.500.11850/670546/dashProps.zip",
+    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/bitstreams/5a2f3c94-beb6-431f-b646-62aa8519acbd/download",
 }
 DATA_DICT = {
     DataPath.DEFAULT: default_dash_tree_path,


### PR DESCRIPTION
The download link for the research archive was out of date (still worked in browser but not using `urlretrieve`).

Replacing it with the (new) link retrieved from the research-archive fixed the problem.

Thanks @cschiebroek for pointing this out