### PR TITLE
correctly specify package location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,8 @@ classifiers = [
 "DASH Properties" = "https://doi.org/10.1063/5.0218154"
 
 [tool.setuptools]
+packages = ["serenityff"]
 include-package-data = true
-
-[tool.setuptools.packages.find]
-where = ["serenityff"]
 
 [project.entry-points."openff.toolkit.plugins.handlers"]
 SerenityFFCharge = "serenityff.charge.utils.serenityff_charge_handler:SerenityFFChargeHandler"


### PR DESCRIPTION
Installing DASH using `python -m pip install git+https://github.com/rinikerlab/DASH-tree` failed after moving to pyproject.toml

Fixing this by setting packages = ["serenityff"] instead of packages.find.where = ["serenityff"]