### PR TITLE
Fix DASH-Props download URL (500 error from /bitstreams/<uuid>/download)

### DIFF
--- a/serenityff/charge/tree/retrieve_data.py
+++ b/serenityff/charge/tree/retrieve_data.py
@@ -29,7 +29,7 @@ class DataPath(Enum):
 
 URL_DICT = {
     DataUrl.DEFAULT: None,
-    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/bitstreams/5a2f3c94-beb6-431f-b646-62aa8519acbd/download",
+    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/server/api/core/bitstreams/5a2f3c94-beb6-431f-b646-62aa8519acbd/content",
 }
 DATA_DICT = {
     DataPath.DEFAULT: default_dash_tree_path,


### PR DESCRIPTION
## Summary
- The URL set in `serenityff/charge/tree/retrieve_data.py` (`https://www.research-collection.ethz.ch/bitstreams/<uuid>/download`) currently returns **HTTP 500** from the ETHZ Research Collection server, so `DASHTree(tree_type=TreeType.FULL)` fails on first use with `zipfile.BadZipFile: File is not a zip file` (the error page is saved as the zip).
- Switching to the DSpace REST API content endpoint (`/server/api/core/bitstreams/<uuid>/content`) returns the same `dashProps.zip` reliably (verified end-to-end: download, extract, `get_property_noNAN`, `get_molecules_partial_charges` with `chg_key="AM1BCC"`).

## Test plan
- [ ] On a fresh environment, instantiate `DASHTree(tree_folder_path=dash_props_tree_path, tree_type=TreeType.FULL)` — should download ~577 MB and complete without `DataExtractionError`.
- [ ] `tree.get_property_noNAN(mol=Chem.AddHs(Chem.MolFromSmiles('CCO')), atom=0, property_name='DFTD4:C6')` returns a numeric value (≈ 28.18).
- [ ] `tree.get_molecules_partial_charges(mol, chg_key='AM1BCC', chg_std_key='AM1BCC_std')['charges']` sums to 0 for neutral ethanol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)