### PR TITLE
Fix broken Research Collection Link

### DIFF
--- a/dev/conda-env/test_env.yaml
+++ b/dev/conda-env/test_env.yaml
@@ -10,6 +10,7 @@ dependencies:
   - python = 3.10
   - pip
   # Dev
+  - setuptools < 82.0.0
   - pytest
   - pytest-cov
   - codecov

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - numba
   - ambertools = 23.3
   - openff-toolkit = 0.10.0
+  - setuptools < 82.0.0
   - rdkit
   - pytorch = 2.0.0
   - pyg = 2.3.0

--- a/min_environment.yml
+++ b/min_environment.yml
@@ -13,4 +13,5 @@ dependencies:
   - numba
   - ambertools = 23.3
   - openff-toolkit = 0.10.0
+  - setuptools < 82.0.0
   - rdkit

--- a/serenityff/charge/tree/retrieve_data.py
+++ b/serenityff/charge/tree/retrieve_data.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024-2025 ETH Zurich, Niels Maeder and other DASH contributors.
 
 """Functionality to obtain the DASH properties data from ETH research archive."""
+
 import zipfile
 from enum import Enum, auto
 from pathlib import Path
@@ -29,7 +30,7 @@ class DataPath(Enum):
 
 URL_DICT = {
     DataUrl.DEFAULT: None,
-    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/bitstreams/5a2f3c94-beb6-431f-b646-62aa8519acbd/download",
+    DataUrl.DASH_PROPS: "https://www.research-collection.ethz.ch/server/api/core/bitstreams/5a2f3c94-beb6-431f-b646-62aa8519acbd/content",
 }
 DATA_DICT = {
     DataPath.DEFAULT: default_dash_tree_path,
@@ -37,7 +38,9 @@ DATA_DICT = {
 }
 
 
-def download_tree_data_from_archive(url: str = URL_DICT[DataUrl.DASH_PROPS], file: Path = ZIP_FILE) -> None:
+def download_tree_data_from_archive(
+    url: str = URL_DICT[DataUrl.DASH_PROPS], file: Path = ZIP_FILE
+) -> None:
     """Download additional DASH Properties data.
 
     Gets the data uploaded to the ETH-research archive for the DASH-Props
@@ -56,7 +59,9 @@ def download_tree_data_from_archive(url: str = URL_DICT[DataUrl.DASH_PROPS], fil
         raise DataDownloadError("URL for additional data cannot be None")
 
 
-def extract_data(zip_archive: Path = ZIP_FILE, folder: Path = additional_data_dir) -> None:
+def extract_data(
+    zip_archive: Path = ZIP_FILE, folder: Path = additional_data_dir
+) -> None:
     """
     Extract the Downloaded Zip archive to be readable by the DASH-Tree constructor.
 
@@ -127,7 +132,9 @@ def get_additional_data(
         extracted_folder = DATA_DICT[extracted_folder]
     if data_is_complete(folder=extracted_folder):
         return True
-    print("The DASH Tree is missing additional data and will install that. This Can take a few minutes...")
+    print(
+        "The DASH Tree is missing additional data and will install that. This Can take a few minutes..."
+    )
     download_tree_data_from_archive(url=url, file=zip_archive)
     extract_data(zip_archive=zip_archive, folder=add_data_folder)
     return data_is_complete(folder=extracted_folder)

--- a/serenityff/charge/tree/retrieve_data.py
+++ b/serenityff/charge/tree/retrieve_data.py
@@ -38,9 +38,7 @@ DATA_DICT = {
 }
 
 
-def download_tree_data_from_archive(
-    url: str = URL_DICT[DataUrl.DASH_PROPS], file: Path = ZIP_FILE
-) -> None:
+def download_tree_data_from_archive(url: str = URL_DICT[DataUrl.DASH_PROPS], file: Path = ZIP_FILE) -> None:
     """Download additional DASH Properties data.
 
     Gets the data uploaded to the ETH-research archive for the DASH-Props
@@ -59,9 +57,7 @@ def download_tree_data_from_archive(
         raise DataDownloadError("URL for additional data cannot be None")
 
 
-def extract_data(
-    zip_archive: Path = ZIP_FILE, folder: Path = additional_data_dir
-) -> None:
+def extract_data(zip_archive: Path = ZIP_FILE, folder: Path = additional_data_dir) -> None:
     """
     Extract the Downloaded Zip archive to be readable by the DASH-Tree constructor.
 
@@ -132,9 +128,7 @@ def get_additional_data(
         extracted_folder = DATA_DICT[extracted_folder]
     if data_is_complete(folder=extracted_folder):
         return True
-    print(
-        "The DASH Tree is missing additional data and will install that. This Can take a few minutes..."
-    )
+    print("The DASH Tree is missing additional data and will install that. This Can take a few minutes...")
     download_tree_data_from_archive(url=url, file=zip_archive)
     extract_data(zip_archive=zip_archive, folder=add_data_folder)
     return data_is_complete(folder=extracted_folder)


### PR DESCRIPTION
Adapting the link for retrieving extra data from the ethz research collection.

also minimal formatting changes to the file.

Pinning `setuptools < 82.0` to make sure `pkg_resources` is still installed for the use of the off handler - found here https://blog.arshanaslam.me/fixing-no-module-named-pkgresources-after-setuptools-82-removal