### PR TITLE
Remove defaults channel from environment files

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: dash
 channels:
-  - defaults
   - conda-forge
   - pytorch
   - pyg

--- a/min_environment.yml
+++ b/min_environment.yml
@@ -1,6 +1,5 @@
 name: dash
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python


### PR DESCRIPTION
The `defaults` conda channel is the one that has licensing/usage restrictions associated with it.
The `conda-forge` channel should provide everything we need.